### PR TITLE
Remove redundant class name in TimePicker

### DIFF
--- a/src/components/DateTimePicker/TimePicker.tsx
+++ b/src/components/DateTimePicker/TimePicker.tsx
@@ -164,7 +164,7 @@ export class TimePicker extends React.Component<ITimePickerProps, any> {
         } else {
             minuteDisp = minute.toString();
         }
-        let hourClasses = classNames('time-picker-hours', 'textField-field',
+        let hourClasses = classNames('time-picker-hours',
             {
                 isSelected: this.hourHover
             });


### PR DESCRIPTION
 -'textField-field' should not be in hourClasses