### PR TITLE
Optional dropdown open/close controlled from props

### DIFF
--- a/src/components/Dropdown/Dropdown.Props.ts
+++ b/src/components/Dropdown/Dropdown.Props.ts
@@ -22,6 +22,7 @@ export interface IDropdownProps {
   onClosed?: () => void;
   onMenuToggle?: (opened: boolean) => void;
   onCustomSelectionText?: () => string;
+  isOpen?: boolean;
 }
 
 export interface IDropdownOption {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -102,7 +102,7 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
           onKeyDown={this._onDropdownKeyDown}
           onClick={this._onDropdownClick}
           role="combobox"
-          >
+        >
           <span className={dropdownTitleClassName}>
             {icon && (
               <Icon iconName={icon}></Icon>
@@ -120,7 +120,7 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
             targetElement={this._dropDown}
             directionalHint={DirectionalHint.bottomLeftEdge}
             onDismiss={this._onDismiss}
-            >
+          >
             {dropdownType === DropdownType.customDropdown ? (
               <ul ref={(c: HTMLElement) => this._optionList = c}
                 id={id + '-list'}
@@ -199,6 +199,9 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
     this.setState({
       isOpen: false
     });
+    if (this.props.onMenuToggle) {
+      this.props.onMenuToggle(false);  // return next state of opened
+    }
   }
 
   @autobind
@@ -206,6 +209,9 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
     this.setState({ isOpen: false });
     if (this.props.onClosed) {
       this.props.onClosed();
+    }
+    if (this.props.onMenuToggle) {
+      this.props.onMenuToggle(false);  // return next state of opened
     }
   }
 
@@ -220,12 +226,18 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
         this.setState({
           isOpen: !this.state.isOpen
         });
+        if (this.props.onMenuToggle) {
+          this.props.onMenuToggle(false);  // return next state of opened
+        }
         break;
 
       case KeyCodes.escape:
         this.setState({
           isOpen: false
         });
+        if (this.props.onMenuToggle) {
+          this.props.onMenuToggle(false);  // return next state of opened
+        }
         break;
 
       case KeyCodes.up:

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -227,7 +227,7 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
           isOpen: !this.state.isOpen
         });
         if (this.props.onMenuToggle) {
-          this.props.onMenuToggle(false);  // return next state of opened
+          this.props.onMenuToggle(!this.state.isOpen);  // return next state of opened
         }
         break;
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -42,14 +42,19 @@ export class Dropdown extends React.Component<IDropdownProps, any> {
 
     this.state = {
       id: getId('Dropdown'),
-      isOpen: false,
+      isOpen: props.isOpen !== undefined ? props.isOpen : false,
       selectedIndex: this._getSelectedIndex(props.options, props.selectedKey)
     };
   }
 
   public componentWillReceiveProps(newProps: IDropdownProps) {
+    let isOpen = this.state.isOpen;
+    if (newProps.isOpen !== undefined) {
+      isOpen = newProps.isOpen;
+    }
     this.setState({
-      selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey)
+      selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey),
+      isOpen: isOpen
     });
   }
 


### PR DESCRIPTION
There was no way (as I am familiar) to close custom dropdown, so this prop can be used when building custom dropdowns with controlled open / close state.