### PR TITLE
Feat/tree filter modifications

### DIFF
--- a/examples/MockData/treeFilterElements.ts
+++ b/examples/MockData/treeFilterElements.ts
@@ -19,11 +19,10 @@ export function createRandomizedData(numOfItems, maxDepth) {
         for (let i = 0; i < numChildren; i++) {
             children.push(createRandomizedItem(key + '-' + i, depth + 1));
         }
-        let expanded = numChildren > 0 && Math.random() < .25;
         return {
             id: key,
             value: key + ' ' + name,
-            expanded: expanded,
+            expanded: false,
             children: children
         };
     };

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -32,13 +32,15 @@ export class Index extends React.Component<any, DemoState> {
         return (
             <div style={{ paddingLeft: 300 }}>
                 <TreeFilter
-                    title="Tree Filter"
+                    title="Tree Filter (max size)"
                     filterId={'f1'}
                     items={treeData}
                     onValuesSelected={this.onValuesSelected}
                     // tslint:disable-next-line:no-string-literal
                     filterSelection={this.state.filterStates['f1']}
                     defaultSelection={FilterSelectionEnum.All}
+                    maxWidth={700}
+                    maxHeight={500}
                 />
                  <TreeFilter
                     title="Tree Filter - depth 4"

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -1,14 +1,14 @@
 import { DirectionalHint } from '../../utilities/DirectionalHint';
 
 export enum FilterSelectionEnum {
-  All,
-  None,
-  Selected
+    All,
+    None,
+    Selected
 }
 
 export interface IFilterSelection {
-  type: FilterSelectionEnum;
-  selectedIDs: Array<string>;
+    type: FilterSelectionEnum;
+    selectedIDs: Array<string>;
 }
 
 export enum CheckStatus {
@@ -32,11 +32,32 @@ export interface ITreeFilterProps {
     height?: number;
     minWidth?: number;
     minHeight?: number;
+    maxWidth?: number;
+    maxHeight?: number;
     directionalHint?: DirectionalHint;
+    clearSearchOnClose?: boolean; 
 }
 
+export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
+    title: 'Title',
+    filterId: 'treeFilter',
+    hasSearch: true,
+    isSingleSelect: false,
+    itemsAreFlatList: false,
+    isGroupSelectableOnSingleSelect: false,
+    directionalHint: DirectionalHint.bottomRightEdge,
+    onValuesSelected: () => { },
+    filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
+    width: 300,
+    height: 350,
+    minWidth: 200,
+    minHeight: 200,
+    defaultSelection: FilterSelectionEnum.None,
+    clearSearchOnClose: true
+};
+
 export interface ITreeFilterState {
-    isOpen: boolean;    
+    isOpen: boolean;
     filteredItems: Array<TreeItem>;
     searchText: string;
     partiallyCheckedItemIds: Array<string>;   // items with selected children - different name?

--- a/src/components/TreeFilter/TreeFilter.scss
+++ b/src/components/TreeFilter/TreeFilter.scss
@@ -18,6 +18,11 @@
     }
     .item-container {
         white-space: nowrap;
+        cursor: pointer;
+        user-select: none;
+    }
+    .item-container:hover {
+        background-color: $font-info-colorBackground
     }
     .tree-expand-icon {
         vertical-align: middle;
@@ -39,6 +44,23 @@
             padding-left: 5px;
         }
     }
+    .filter-search {
+        height: 30px;
+        line-height: 30px;
+        margin: 0;
+        width: 100%;
+        .search-icon {
+            line-height: 30px;
+        }
+        .search-field {
+            height: 30px;
+            line-height: 30px;
+        }
+        .search-clearButton {
+            line-height: 28px;
+            font-size: 14px;
+        }
+    }
 }
 
 .tree-filter-container {
@@ -55,13 +77,19 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
+        .dropdown-icon {
+            float: right;
+            padding-top: 6px;
+            padding-right: 1px;
+            font-size: 11px;
+        }
     }
     .item-selected {
         color: $secondary-color;
     }
     .reset-filter-icon {
-        font-size: $font-size-s;
+        font-size: 11px;
         float: right;
-        margin-top: 3px;
+        margin-top: 6px;
     }
 }

--- a/src/components/TreeFilter/TreeFilterCheckBox.scss
+++ b/src/components/TreeFilter/TreeFilterCheckBox.scss
@@ -7,6 +7,8 @@ $Checkbox-label-size: 20px;
     font-family: $font-family-base;
     font-size: $font-size-m;
     position: relative;
+    width: 100%;
+    cursor: pointer;
     .checkbox-input {
         position: absolute;
         opacity: 0;
@@ -43,6 +45,9 @@ $Checkbox-label-size: 20px;
         margin-left: 2px;
         font-size: 12px;
     }
+}
+.TreeFilter-checkbox:hover {
+    background-color: $font-info-colorBackground
 }
 
 .icon-partial-selected {

--- a/src/components/TreeFilter/TreeItemOperators.ts
+++ b/src/components/TreeFilter/TreeItemOperators.ts
@@ -94,16 +94,19 @@ export class ItemOperator {
     static filterItems = (items: Array<TreeItem>, lowerCaseSearchText: string): Array<TreeItem> => {
         let filteredItems: Array<TreeItem> = [];
         if (items == null || items.length === 0) { return filteredItems; }
+
         for (let item of items) {
-            if (lowerCaseSearchText === '' || item.value.toLowerCase().search(lowerCaseSearchText) !== -1) {
+            if (lowerCaseSearchText === '') {
                 filteredItems.push(item);
-            } else if (itemHasChildren(item)) { // item does not match search -> check children
+            } else if (itemHasChildren(item)) {
                 const filteredChildren = ItemOperator.filterItems(item.children, lowerCaseSearchText);
                 if (filteredChildren.length > 0) {
-                    let newItem: TreeItem = { ...item, children: filteredChildren };
+                    let newItem: TreeItem = { ...item, children: filteredChildren, expanded: true };
                     filteredItems.push(newItem);
                 }
-            }
+            } else if (item.value.toLowerCase().search(lowerCaseSearchText) !== -1) {
+                filteredItems.push(item);
+            }         
         }
         return filteredItems;
     }


### PR DESCRIPTION
- added props for max width/height 
- fixed that the whole item row is clickable for check/uncheck
- reset-to-default button resets the search 
- search reset when the filter callout is closed - if clearSearchOnClose property is true 
- the search filters all leaf items, the non-leafs are now ignored in the search 
- all nodes are expanded on search
- added hover color on list items 
- disabled list item highlight/select
- mouse icon changed 