### PR TITLE
GroupBy now properly works with valueMember and dataMember

### DIFF
--- a/src/components/QuickGrid/DataSelectors.ts
+++ b/src/components/QuickGrid/DataSelectors.ts
@@ -47,6 +47,6 @@ const getSortedRows = createSelector(getInputRows, getSortColumn, getSortDirecti
         return sortRows(rows, sortColumn, sortDirection, groupBy, columns);
     });
 
-export const getRowsSelector = createSelector(getSortedRows, getGroupBy, getExpandedRows, (rows, groupedColumns, expandedRows = {}) => {
-    return groupRows(rows, groupedColumns, expandedRows);
+export const getRowsSelector = createSelector(getSortedRows, getGroupBy, getExpandedRows, getColumns, (rows, groupedColumns, expandedRows, columns = {}) => {
+    return groupRows(rows, groupedColumns, expandedRows, columns);
 });

--- a/src/components/QuickGrid/DataSelectors.ts
+++ b/src/components/QuickGrid/DataSelectors.ts
@@ -47,6 +47,6 @@ const getSortedRows = createSelector(getInputRows, getSortColumn, getSortDirecti
         return sortRows(rows, sortColumn, sortDirection, groupBy, columns);
     });
 
-export const getRowsSelector = createSelector(getSortedRows, getGroupBy, getExpandedRows, getColumns, (rows, groupedColumns, expandedRows, columns = {}) => {
+export const getRowsSelector = createSelector(getSortedRows, getGroupBy, getExpandedRows, getColumns, (rows, groupedColumns, expandedRows = {}, columns) => {
     return groupRows(rows, groupedColumns, expandedRows, columns);
 });

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -41,8 +41,8 @@ export interface IQuickGridState {
 export interface GroupRow {
     type: 'GroupRow';
     columnGroupName: string;
-    name: string;
-    displayName?: string;
+    groupValue: string;
+    groupDisplayName?: string;
     depth: number;
     groupKey: string;
     isExpanded: boolean;

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -42,6 +42,7 @@ export interface GroupRow {
     type: 'GroupRow';
     columnGroupName: string;
     name: string;
+    displayName?: string;
     depth: number;
     groupKey: string;
     isExpanded: boolean;

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -195,7 +195,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             const toggleRow = () => {
                 this.onRowExpandToggle(rowData.columnGroupName, rowData.groupKey, !rowData.isExpanded);
             };
-            let groupByFormat = `${columnName}: ${rowData.name}`;
+            let groupByFormat = `${columnName}: ${rowData.displayName}`;
             if (this.props.groupRowFormat) {
                 groupByFormat = this.props.groupRowFormat(rowData);
             }

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -195,7 +195,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             const toggleRow = () => {
                 this.onRowExpandToggle(rowData.columnGroupName, rowData.groupKey, !rowData.isExpanded);
             };
-            let groupByFormat = `${columnName}: ${rowData.displayName}`;
+            let groupByFormat = `${columnName}: ${rowData.groupDisplayName}`;
             if (this.props.groupRowFormat) {
                 groupByFormat = this.props.groupRowFormat(rowData);
             }

--- a/src/components/QuickGrid/rowGrouper.ts
+++ b/src/components/QuickGrid/rowGrouper.ts
@@ -23,20 +23,17 @@ class RowGrouper {
         let nextColumnIndex = groupByColumnIndex;
         let groupByColumn = this.groupByColumns[groupByColumnIndex];
         let columnName = groupByColumn.column;
-        let displayName =  _.find(this.columns, x => x.valueMember === columnName).dataMember;
+        let column =  _.find(this.columns, x => x.valueMember === columnName);
+        let displayName = column.dataMember ?  column.dataMember : column.valueMember;
         let groupedRows = _.groupBy(rows, columnName);
-        let groupKeys = _.uniqWith(rows.map(function(o) {
-            return {
-                 value : o[columnName],
-                 display : o[displayName]
-            };
-        }), _.isEqual);
+        let groupKeys = _.uniq(_.map<any, string>(rows, columnName));
         let dataViewRows = [];
         for (let i = 0; i < groupKeys.length; i++) {
-            let groupKeyValue = groupKeys[i].value;
+            let groupKeyValue = groupKeys[i];
+            let groupItem = groupedRows[groupKeyValue][0];
             const groupKey = parentGroupKey + '||' + groupKeyValue;
             let isExpanded = this.isRowExpanded(columnName, groupKey);
-            const rowGroupHeader: GroupRow = { type: 'GroupRow', columnGroupName: columnName, displayName: groupKeys[i].display, name: groupKeyValue, groupKey: groupKey, depth: groupByColumnIndex, isExpanded: isExpanded };
+            const rowGroupHeader: GroupRow = { type: 'GroupRow', columnGroupName: columnName, groupDisplayName: groupItem[displayName], groupValue: groupKeyValue, groupKey: groupKey, depth: groupByColumnIndex, isExpanded: isExpanded };
             dataViewRows.push(rowGroupHeader);
             if (isExpanded) {
                 nextColumnIndex = groupByColumnIndex + 1;

--- a/src/components/QuickGrid/rowGrouper.ts
+++ b/src/components/QuickGrid/rowGrouper.ts
@@ -1,11 +1,13 @@
 import * as _ from 'lodash';
-import { GroupRow, IGroupBy } from './QuickGrid.Props';
+import { GroupRow, IGroupBy, GridColumn } from './QuickGrid.Props';
 class RowGrouper {
     groupByColumns: Array<IGroupBy>;
+    columns: Array<GridColumn>;
     expandedRows: any;
-        constructor(groupByColumns, expandedRows) {
+        constructor(groupByColumns, expandedRows, columns) {
         this.groupByColumns = groupByColumns.slice(0);
         this.expandedRows = expandedRows;
+        this.columns = columns.slice(0);
     }
 
     isRowExpanded(columnName, name) {
@@ -19,15 +21,22 @@ class RowGrouper {
 
     groupRowsByColumn(rows, groupByColumnIndex = 0, parentGroupKey = '') {
         let nextColumnIndex = groupByColumnIndex;
-        let columnName = this.groupByColumns[groupByColumnIndex].column;
+        let groupByColumn = this.groupByColumns[groupByColumnIndex];
+        let columnName = groupByColumn.column;
+        let displayName =  _.find(this.columns, x => x.valueMember === columnName).dataMember;
         let groupedRows = _.groupBy(rows, columnName);
-        let groupKeys = _.uniq(_.map<any, string>(rows, columnName));
+        let groupKeys = _.uniqWith(rows.map(function(o) {
+            return {
+                 value : o[columnName],
+                 display : o[displayName]
+            };
+        }), _.isEqual);
         let dataViewRows = [];
         for (let i = 0; i < groupKeys.length; i++) {
-            let groupKeyValue = groupKeys[i];
+            let groupKeyValue = groupKeys[i].value;
             const groupKey = parentGroupKey + '||' + groupKeyValue;
             let isExpanded = this.isRowExpanded(columnName, groupKey);
-            const rowGroupHeader: GroupRow = { type: 'GroupRow', columnGroupName: columnName, name: groupKeyValue, groupKey: groupKey, depth: groupByColumnIndex, isExpanded: isExpanded };
+            const rowGroupHeader: GroupRow = { type: 'GroupRow', columnGroupName: columnName, displayName: groupKeys[i].display, name: groupKeyValue, groupKey: groupKey, depth: groupByColumnIndex, isExpanded: isExpanded };
             dataViewRows.push(rowGroupHeader);
             if (isExpanded) {
                 nextColumnIndex = groupByColumnIndex + 1;
@@ -43,11 +52,11 @@ class RowGrouper {
     }
 }
 
-export const groupRows = (rows, groupedColumns, expandedRows) => {
+export const groupRows = (rows, groupedColumns, expandedRows, columns) => {
     if (groupedColumns.length === 0) {
         return rows;
     }
-    let rowGrouper = new RowGrouper(groupedColumns, expandedRows);
+    let rowGrouper = new RowGrouper(groupedColumns, expandedRows, columns);
     return rowGrouper.groupRowsByColumn(rows, 0);
 };
 

--- a/src/components/QuickGrid/rowGrouper.ts
+++ b/src/components/QuickGrid/rowGrouper.ts
@@ -4,10 +4,11 @@ class RowGrouper {
     groupByColumns: Array<IGroupBy>;
     columns: Array<GridColumn>;
     expandedRows: any;
-        constructor(groupByColumns, expandedRows, columns) {
-        this.groupByColumns = groupByColumns.slice(0);
+
+    constructor(groupByColumns, expandedRows, columns) {
+        this.groupByColumns = [...groupByColumns];
         this.expandedRows = expandedRows;
-        this.columns = columns.slice(0);
+        this.columns = [...columns];
     }
 
     isRowExpanded(columnName, name) {


### PR DESCRIPTION
ValueMember in quickGrid is used for sort/group value while dataMember for display. GroupBy is now properly shows dataMember while grouping